### PR TITLE
Interpreter 11

### DIFF
--- a/modules/common/src/main/kotlin/common/exception/InterpreterException.kt
+++ b/modules/common/src/main/kotlin/common/exception/InterpreterException.kt
@@ -19,3 +19,7 @@ class DivisionByZeroException : InterpreterException("Division by zero")
 class UninitializedVariableException(
     identifier: String,
 ) : InterpreterException("Variable '$identifier' is used before being initialized")
+
+class InvalidTypeConversionError(
+    message: String,
+) : InterpreterException("Invalid type conversion: $message")

--- a/modules/interpreter/src/main/kotlin/interpreter/Environment.kt
+++ b/modules/interpreter/src/main/kotlin/interpreter/Environment.kt
@@ -5,6 +5,7 @@ import common.enums.TypeEnum
 import common.exception.InterpreterException
 import common.exception.TypeMismatchException
 import common.exception.UndefinedVariableException
+import common.exception.UninitializedVariableException
 
 data class Variable(
     val type: TypeEnum,
@@ -108,17 +109,9 @@ class Environment {
     fun getValue(name: String): Value {
         for (scope in scopes.asReversed()) {
             scope[name]?.let { variable ->
-                return variable.value ?: getDefaultValue(variable.type)
+                return variable.value ?: throw UninitializedVariableException(name)
             }
         }
         throw UndefinedVariableException(name)
     }
-
-    private fun getDefaultValue(type: TypeEnum): Value =
-        when (type) {
-            TypeEnum.NUMBER -> NumberValue(0.0)
-            TypeEnum.STRING -> StringValue("")
-            TypeEnum.BOOLEAN -> BooleanValue(false)
-            else -> throw InterpreterException("Cannot get default value for unsupported type: $type")
-        }
 }

--- a/modules/interpreter/src/main/kotlin/interpreter/Environment.kt
+++ b/modules/interpreter/src/main/kotlin/interpreter/Environment.kt
@@ -19,7 +19,12 @@ sealed class Value {
 data class NumberValue(
     val value: Double,
 ) : Value() {
-    override fun toStringValue(): String = value.toString()
+    override fun toStringValue(): String =
+        if (value % 1.0 == 0.0) {
+            value.toInt().toString()
+        } else {
+            value.toString()
+        }
 }
 
 data class StringValue(

--- a/modules/interpreter/src/main/kotlin/interpreter/Environment.kt
+++ b/modules/interpreter/src/main/kotlin/interpreter/Environment.kt
@@ -5,7 +5,6 @@ import common.enums.TypeEnum
 import common.exception.InterpreterException
 import common.exception.TypeMismatchException
 import common.exception.UndefinedVariableException
-import common.exception.UninitializedVariableException
 
 data class Variable(
     val type: TypeEnum,
@@ -104,9 +103,17 @@ class Environment {
     fun getValue(name: String): Value {
         for (scope in scopes.asReversed()) {
             scope[name]?.let { variable ->
-                return variable.value ?: throw UninitializedVariableException(name)
+                return variable.value ?: getDefaultValue(variable.type)
             }
         }
         throw UndefinedVariableException(name)
     }
+
+    private fun getDefaultValue(type: TypeEnum): Value =
+        when (type) {
+            TypeEnum.NUMBER -> NumberValue(0.0)
+            TypeEnum.STRING -> StringValue("")
+            TypeEnum.BOOLEAN -> BooleanValue(false)
+            else -> throw InterpreterException("Cannot get default value for unsupported type: $type")
+        }
 }

--- a/modules/interpreter/src/main/kotlin/interpreter/Interpreter.kt
+++ b/modules/interpreter/src/main/kotlin/interpreter/Interpreter.kt
@@ -43,7 +43,6 @@ class Interpreter {
             is MonoOpNode -> evaluateMonoOp(node)
             is IfStatementNode -> evaluateIfStatement(node)
             is BlockStatementNode -> evaluateBlockStatement(node)
-            else -> throw InterpreterException("Unknown AST node type: ${node::class.simpleName}") // TODO: add support for other nodes
         }
 
     private fun evaluateIfStatement(node: IfStatementNode): Value? {
@@ -221,7 +220,6 @@ class Interpreter {
             }
 
             TypeEnum.ANY -> {}
-            else -> throw InterpreterException("Unsupported type: $type")
         }
     }
 

--- a/modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt
@@ -30,7 +30,7 @@ class InterpreterOnePointOneTest {
         interpreter = Interpreter { mockInput ?: "" }
     }
 
-    // =================== CONST DECLARATIONS TESTS ===================
+    // Const
 
     @Test
     fun testConstDeclarationBasic() {
@@ -90,7 +90,7 @@ class InterpreterOnePointOneTest {
         assertEquals(listOf("10"), result)
     }
 
-    // =================== BOOLEAN TYPE SUPPORT TESTS ===================
+    // Boolean
 
     @Test
     fun testBooleanLiteralTrue() {
@@ -132,7 +132,7 @@ class InterpreterOnePointOneTest {
         assertEquals(listOf("true"), result)
     }
 
-    // =================== IF STATEMENT TESTS ===================
+    // If
 
     @Test
     fun testIfStatementWithTrueCondition() {
@@ -245,7 +245,7 @@ class InterpreterOnePointOneTest {
         assertEquals(listOf("First", "Second"), result)
     }
 
-    // =================== READINPUT FUNCTION TESTS ===================
+    // readInput
 
     @Test
     fun testReadInputReturnsCorrectTypeForString() {
@@ -297,7 +297,7 @@ class InterpreterOnePointOneTest {
         assertEquals(listOf("Direct Input"), result)
     }
 
-    // =================== READENV FUNCTION TESTS ===================
+    // readEnv
 
     @Test
     fun testReadEnvNotFoundThrowsException() {
@@ -311,7 +311,7 @@ class InterpreterOnePointOneTest {
         }
     }
 
-    // =================== COMPLEX SCENARIOS ===================
+    // mixed
 
     @Test
     fun testConstWithIfStatement() {
@@ -379,7 +379,7 @@ class InterpreterOnePointOneTest {
         assertEquals(listOf("PrintScript v1.1"), result)
     }
 
-    // =================== ERROR CASES AND EDGE CASES ===================
+    // errors
 
     @Test
     fun testTypeMismatchInBooleanDeclaration() {
@@ -448,60 +448,5 @@ class InterpreterOnePointOneTest {
         assertThrows(UndefinedVariableException::class.java) {
             interpreter.interpret(listOf(ifStatement))
         }
-    }
-
-    // =================== VERSION COMPATIBILITY TESTS ===================
-
-    @Test
-    fun testVersion10ShouldNotSupportBoolean() {
-        // This test would check that v1.0 mode rejects boolean literals
-        // Implementation would depend on version parameter in interpreter
-        val literal = LiteralNode(true, TypeEnum.BOOLEAN)
-        val println = FunctionNode(FunctionEnum.PRINTLN, literal)
-
-        // In v1.0 mode, this should throw an exception
-        // assertThrows(InterpreterException::class.java) {
-        //     interpreterV10.interpret(listOf(println))
-        // }
-    }
-
-    @Test
-    fun testVersion10ShouldNotSupportIfStatements() {
-        // This test would check that v1.0 mode rejects if statements
-        // Implementation would depend on version parameter in interpreter
-        val condition = LiteralNode(true, TypeEnum.BOOLEAN)
-        val thenBlock = BlockStatementNode(emptyList())
-        val ifStatement = IfStatementNode(condition, thenBlock, null)
-
-        // In v1.0 mode, this should throw an exception
-        // assertThrows(InterpreterException::class.java) {
-        //     interpreterV10.interpret(listOf(ifStatement))
-        // }
-    }
-
-    @Test
-    fun testVersion10ShouldNotSupportReadInput() {
-        // This test would check that v1.0 mode rejects readInput
-        val prompt = LiteralNode("Enter value: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READ_INPUT, prompt)
-        val println = FunctionNode(FunctionEnum.PRINTLN, readInputCall)
-
-        // In v1.0 mode, this should throw an exception
-        // assertThrows(InterpreterException::class.java) {
-        //     interpreterV10.interpret(listOf(println))
-        // }
-    }
-
-    @Test
-    fun testVersion10ShouldNotSupportReadEnv() {
-        // This test would check that v1.0 mode rejects readEnv
-        val envVar = LiteralNode("PATH", TypeEnum.STRING)
-        val readEnvCall = FunctionNode(FunctionEnum.READ_ENV, envVar)
-        val println = FunctionNode(FunctionEnum.PRINTLN, readEnvCall)
-
-        // In v1.0 mode, this should throw an exception
-        // assertThrows(InterpreterException::class.java) {
-        //     interpreterV10.interpret(listOf(println))
-        // }
     }
 }

--- a/modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt
@@ -1,6 +1,6 @@
 package interpreter
 
-/*import common.ast.AssignmentNode
+import common.ast.AssignmentNode
 import common.ast.BinaryOpNode
 import common.ast.BlockStatementNode
 import common.ast.DeclaratorNode
@@ -19,15 +19,15 @@ import common.exception.UndefinedVariableException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test*/
+import org.junit.jupiter.api.Test
 
-class PrintScriptInterpreter11Test {
-/*
-    private lateinit var interpreter: PrintScriptInterpreter
+class InterpreterOnePointOneTest {
+    private lateinit var interpreter: Interpreter
+    private var mockInput: String? = null
 
     @BeforeEach
     fun setUp() {
-        interpreter = PrintScriptInterpreter()
+        interpreter = Interpreter { mockInput ?: "" }
     }
 
     // =================== CONST DECLARATIONS TESTS ===================
@@ -87,7 +87,7 @@ class PrintScriptInterpreter11Test {
         val println = FunctionNode(FunctionEnum.PRINTLN, IdentifierNode("x"))
 
         val result = interpreter.interpret(listOf(declarator, assignment, println))
-        assertEquals(listOf("10.0"), result)
+        assertEquals(listOf("10"), result)
     }
 
     // =================== BOOLEAN TYPE SUPPORT TESTS ===================
@@ -248,115 +248,67 @@ class PrintScriptInterpreter11Test {
     // =================== READINPUT FUNCTION TESTS ===================
 
     @Test
-    fun testReadInputWithMockInput() {
-        // This test assumes the interpreter has a way to provide mock input
-        // In real implementation, this would need a mock input provider
-        val prompt = LiteralNode("Enter your name: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READINPUT, prompt)
-        val variableNode = VariableNode("name", TypeEnum.STRING)
-        val declarator = DeclaratorNode(variableNode, readInputCall, DeclarationTypeEnum.LET)
-        val println = FunctionNode(FunctionEnum.PRINTLN, IdentifierNode("name"))
-
-        // Note: This test would need mock input mechanism in actual implementation
-        // For now, we test the AST structure is correct
-        val statements = listOf(declarator, println)
-        // The actual test execution would depend on mock input implementation
-    }
-
-    @Test
     fun testReadInputReturnsCorrectTypeForString() {
+        mockInput = "Test String"
         val prompt = LiteralNode("Enter text: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READINPUT, prompt)
+        val readInputCall = FunctionNode(FunctionEnum.READ_INPUT, prompt)
         val variableNode = VariableNode("text", TypeEnum.STRING)
         val declarator = DeclaratorNode(variableNode, readInputCall, DeclarationTypeEnum.LET)
+        val println = FunctionNode(FunctionEnum.PRINTLN, IdentifierNode("text"))
 
-        // Test that the AST structure is valid for string input
-        val statements = listOf(declarator)
-        // Actual execution would require mock input
+        val result = interpreter.interpret(listOf(declarator, println))
+        assertEquals(listOf("Test String"), result)
     }
 
     @Test
     fun testReadInputReturnsCorrectTypeForNumber() {
+        mockInput = "123.5"
         val prompt = LiteralNode("Enter a number: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READINPUT, prompt)
+        val readInputCall = FunctionNode(FunctionEnum.READ_INPUT, prompt)
         val variableNode = VariableNode("num", TypeEnum.NUMBER)
         val declarator = DeclaratorNode(variableNode, readInputCall, DeclarationTypeEnum.LET)
+        val println = FunctionNode(FunctionEnum.PRINTLN, IdentifierNode("num"))
 
-        // Test that the AST structure is valid for number input
-        val statements = listOf(declarator)
-        // Actual execution would require mock input
+        val result = interpreter.interpret(listOf(declarator, println))
+        assertEquals(listOf("123.5"), result)
     }
 
     @Test
     fun testReadInputReturnsCorrectTypeForBoolean() {
+        mockInput = "true"
         val prompt = LiteralNode("Enter true/false: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READINPUT, prompt)
+        val readInputCall = FunctionNode(FunctionEnum.READ_INPUT, prompt)
         val variableNode = VariableNode("flag", TypeEnum.BOOLEAN)
         val declarator = DeclaratorNode(variableNode, readInputCall, DeclarationTypeEnum.LET)
+        val println = FunctionNode(FunctionEnum.PRINTLN, IdentifierNode("flag"))
 
-        // Test that the AST structure is valid for boolean input
-        val statements = listOf(declarator)
-        // Actual execution would require mock input
+        val result = interpreter.interpret(listOf(declarator, println))
+        assertEquals(listOf("true"), result)
     }
 
     @Test
     fun testReadInputInPrintlnCall() {
+        mockInput = "Direct Input"
         val prompt = LiteralNode("Enter value: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READINPUT, prompt)
+        val readInputCall = FunctionNode(FunctionEnum.READ_INPUT, prompt)
         val println = FunctionNode(FunctionEnum.PRINTLN, readInputCall)
 
-        // Test that readInput can be used directly in println
-        val statements = listOf(println)
-        // Actual execution would require mock input
+        val result = interpreter.interpret(listOf(println))
+        assertEquals(listOf("Direct Input"), result)
     }
 
     // =================== READENV FUNCTION TESTS ===================
 
     @Test
-    fun testReadEnvBasic() {
-        val envVarName = LiteralNode("PATH", TypeEnum.STRING)
-        val readEnvCall = FunctionNode(FunctionEnum.READENV, envVarName)
+    fun testReadEnvNotFoundThrowsException() {
+        val envVarName = "NON_EXISTENT_VAR_12345"
+        val readEnvCall = FunctionNode(FunctionEnum.READ_ENV, LiteralNode(envVarName, TypeEnum.STRING))
         val variableNode = VariableNode("path", TypeEnum.STRING)
         val declarator = DeclaratorNode(variableNode, readEnvCall, DeclarationTypeEnum.LET)
 
-        // Test that the AST structure is valid for environment variable reading
-        val statements = listOf(declarator)
-        // Actual execution would depend on environment setup
-    }
-
-    @Test
-    fun testReadEnvForNumber() {
-        val envVarName = LiteralNode("PORT", TypeEnum.STRING)
-        val readEnvCall = FunctionNode(FunctionEnum.READENV, envVarName)
-        val variableNode = VariableNode("port", TypeEnum.NUMBER)
-        val declarator = DeclaratorNode(variableNode, readEnvCall, DeclarationTypeEnum.LET)
-
-        // Test that environment variables can be converted to numbers
-        val statements = listOf(declarator)
-        // Actual execution would require environment variable setup
-    }
-
-    @Test
-    fun testReadEnvForBoolean() {
-        val envVarName = LiteralNode("DEBUG", TypeEnum.STRING)
-        val readEnvCall = FunctionNode(FunctionEnum.READENV, envVarName)
-        val variableNode = VariableNode("debug", TypeEnum.BOOLEAN)
-        val declarator = DeclaratorNode(variableNode, readEnvCall, DeclarationTypeEnum.LET)
-
-        // Test that environment variables can be converted to booleans
-        val statements = listOf(declarator)
-        // Actual execution would require environment variable setup
-    }
-
-    @Test
-    fun testReadEnvInPrintlnCall() {
-        val envVarName = LiteralNode("USER", TypeEnum.STRING)
-        val readEnvCall = FunctionNode(FunctionEnum.READENV, envVarName)
-        val println = FunctionNode(FunctionEnum.PRINTLN, readEnvCall)
-
-        // Test that readEnv can be used directly in println
-        val statements = listOf(println)
-        // Actual execution would require environment variable setup
+        assertThrows(InterpreterException::class.java) {
+            interpreter.interpret(listOf(declarator))
+        }
     }
 
     // =================== COMPLEX SCENARIOS ===================
@@ -399,8 +351,12 @@ class PrintScriptInterpreter11Test {
     @Test
     fun testMultipleConstsAndVariables() {
         val appName = VariableNode("APP_NAME", TypeEnum.STRING)
-        val appNameDeclarator = DeclaratorNode(appName, LiteralNode("PrintScript", TypeEnum.STRING),
-            DeclarationTypeEnum.CONST)
+        val appNameDeclarator =
+            DeclaratorNode(
+                appName,
+                LiteralNode("PrintScript", TypeEnum.STRING),
+                DeclarationTypeEnum.CONST,
+            )
 
         val version = VariableNode("VERSION", TypeEnum.STRING)
         val versionDeclarator = DeclaratorNode(version, LiteralNode("1.1", TypeEnum.STRING), DeclarationTypeEnum.CONST)
@@ -527,7 +483,7 @@ class PrintScriptInterpreter11Test {
     fun testVersion10ShouldNotSupportReadInput() {
         // This test would check that v1.0 mode rejects readInput
         val prompt = LiteralNode("Enter value: ", TypeEnum.STRING)
-        val readInputCall = FunctionNode(FunctionEnum.READINPUT, prompt)
+        val readInputCall = FunctionNode(FunctionEnum.READ_INPUT, prompt)
         val println = FunctionNode(FunctionEnum.PRINTLN, readInputCall)
 
         // In v1.0 mode, this should throw an exception
@@ -540,7 +496,7 @@ class PrintScriptInterpreter11Test {
     fun testVersion10ShouldNotSupportReadEnv() {
         // This test would check that v1.0 mode rejects readEnv
         val envVar = LiteralNode("PATH", TypeEnum.STRING)
-        val readEnvCall = FunctionNode(FunctionEnum.READENV, envVar)
+        val readEnvCall = FunctionNode(FunctionEnum.READ_ENV, envVar)
         val println = FunctionNode(FunctionEnum.PRINTLN, readEnvCall)
 
         // In v1.0 mode, this should throw an exception
@@ -548,5 +504,4 @@ class PrintScriptInterpreter11Test {
         //     interpreterV10.interpret(listOf(println))
         // }
     }
-*/
 }

--- a/modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt
@@ -50,7 +50,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, addition)
 
         val result = interpreter.interpret(listOf(println))
-        assertEquals(listOf("15.0"), result)
+        assertEquals(listOf("15"), result)
     }
 
     @Test
@@ -72,7 +72,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, addition)
 
         val result = interpreter.interpret(listOf(println))
-        assertEquals(listOf("Value: 42.0"), result)
+        assertEquals(listOf("Value: 42"), result)
     }
 
     @Test
@@ -83,7 +83,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, subtraction)
 
         val result = interpreter.interpret(listOf(println))
-        assertEquals(listOf("7.0"), result)
+        assertEquals(listOf("7"), result)
     }
 
     @Test
@@ -94,7 +94,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, multiplication)
 
         val result = interpreter.interpret(listOf(println))
-        assertEquals(listOf("12.0"), result)
+        assertEquals(listOf("12"), result)
     }
 
     @Test
@@ -105,7 +105,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, division)
 
         val result = interpreter.interpret(listOf(println))
-        assertEquals(listOf("5.0"), result)
+        assertEquals(listOf("5"), result)
     }
 
     @Test
@@ -172,7 +172,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, identifier)
 
         val result = interpreter.interpret(listOf(declarator, println))
-        assertEquals(listOf("42.0"), result)
+        assertEquals(listOf("42"), result)
     }
 
     @Test
@@ -231,7 +231,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, addition)
 
         val result = interpreter.interpret(listOf(decl1, decl2, println))
-        assertEquals(listOf("52.0"), result)
+        assertEquals(listOf("52"), result)
     }
 
     @Test
@@ -266,7 +266,7 @@ class InterpreterTest {
         val println = FunctionNode(FunctionEnum.PRINTLN, IdentifierNode("x"))
 
         val result = interpreter.interpret(listOf(declarator, println))
-        assertEquals(listOf("42.0"), result)
+        assertEquals(listOf("42"), result)
     }
 
     @Test

--- a/modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt
@@ -43,14 +43,6 @@ class InterpreterTest {
     }
 
     @Test
-    fun testBooleanLiteralNotSupported() {
-        val literal = LiteralNode(true, TypeEnum.BOOLEAN)
-        assertThrows(InterpreterException::class.java) {
-            interpreter.interpret(listOf(literal))
-        }
-    }
-
-    @Test
     fun testBinaryOpAdditionNumbers() {
         val left = LiteralNode(10.0, TypeEnum.NUMBER)
         val right = LiteralNode(5.0, TypeEnum.NUMBER)

--- a/modules/interpreter/src/test/kotlin/interpreter/ValueTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/ValueTest.kt
@@ -7,7 +7,7 @@ class ValueTest {
     @Test
     fun testNumberValueToString() {
         val numberValue = NumberValue(42.0)
-        assertEquals("42.0", numberValue.toStringValue())
+        assertEquals("42", numberValue.toStringValue())
     }
 
     @Test
@@ -19,7 +19,7 @@ class ValueTest {
     @Test
     fun testNumberValueToStringWithZero() {
         val numberValue = NumberValue(0.0)
-        assertEquals("0.0", numberValue.toStringValue())
+        assertEquals("0", numberValue.toStringValue())
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces major enhancements to the interpreter, including support for boolean types, if statements, scoped variable environments, and improved input handling. Additionally, it refactors and expands the test suite to cover these new features. The changes are grouped below by theme.

### Interpreter Features

* **Boolean type support:** Added `BooleanValue` as a new subclass of `Value`, updated type checking and conversion logic to handle booleans, and enabled boolean literals and variables in the interpreter. [[1]](diffhunk://#diff-825538f674e84c64d88b0db9a9e65015bc5c4c85b5e620e405c7de7ef3800f82R37-R117) [[2]](diffhunk://#diff-53390c3b47fd8e6762f18a66f4dd34d1bbba099ffe9561dfbd159f6bbc6d3fbeL134-R184) [[3]](diffhunk://#diff-53390c3b47fd8e6762f18a66f4dd34d1bbba099ffe9561dfbd159f6bbc6d3fbeR278-L181)
* **If statement and block support:** Implemented `IfStatementNode` and `BlockStatementNode` evaluation, including proper scoping for variables within blocks.
* **Scoped variable environment:** Refactored the `Environment` class to support nested scopes for variables, enabling correct variable shadowing and isolation in blocks and functions.
* **Input function improvements:** Added type-safe input reading and conversion for variable initializers and print statements, with custom error handling for invalid conversions. [[1]](diffhunk://#diff-53390c3b47fd8e6762f18a66f4dd34d1bbba099ffe9561dfbd159f6bbc6d3fbeL149-R204) [[2]](diffhunk://#diff-53390c3b47fd8e6762f18a66f4dd34d1bbba099ffe9561dfbd159f6bbc6d3fbeR218-R260) [[3]](diffhunk://#diff-e96a7164e535d5f37faad01d407a8b65bd6269e3b9da5a90ff3c7e11b58430bfR22-R25)

### Code Quality and Refactoring

* **Test suite refactor and expansion:** Renamed the main interpreter test file, updated tests to reflect new features (boolean, if statements, scoping, input), and improved test clarity and coverage. [[1]](diffhunk://#diff-b1c1dbdc0e4a612a9549af15b7f416598feaa6731be298c962cbe85b0a65e817L3-R3) [[2]](diffhunk://#diff-b1c1dbdc0e4a612a9549af15b7f416598feaa6731be298c962cbe85b0a65e817L22-R33) [[3]](diffhunk://#diff-b1c1dbdc0e4a612a9549af15b7f416598feaa6731be298c962cbe85b0a65e817L90-R93) [[4]](diffhunk://#diff-b1c1dbdc0e4a612a9549af15b7f416598feaa6731be298c962cbe85b0a65e817L135-R135)