### PR TITLE
feat: implement uninitialized variable handling with separate state r…

### DIFF
--- a/modules/interpreter/src/main/kotlin/interpreter/Interpreter.kt
+++ b/modules/interpreter/src/main/kotlin/interpreter/Interpreter.kt
@@ -10,6 +10,7 @@ import common.ast.IdentifierNode
 import common.ast.IfStatementNode
 import common.ast.LiteralNode
 import common.ast.MonoOpNode
+import common.ast.UninitializedVariableNode
 import common.ast.VariableNode
 import common.enums.FunctionEnum
 import common.enums.OperationEnum
@@ -42,6 +43,7 @@ class Interpreter(
             is BinaryOpNode -> evaluateBinaryOp(node)
             is LiteralNode -> evaluateLiteral(node)
             is DeclaratorNode -> evaluateDeclarator(node)
+            is UninitializedVariableNode -> evaluateUninitializedVariableDeclaration(node)
             is VariableNode -> evaluateVariable(node)
             is IdentifierNode -> evaluateIdentifier(node)
             is AssignmentNode -> evaluateAssignment(node)
@@ -49,8 +51,13 @@ class Interpreter(
             is MonoOpNode -> evaluateMonoOp(node)
             is IfStatementNode -> evaluateIfStatement(node)
             is BlockStatementNode -> evaluateBlockStatement(node)
-            else -> throw InterpreterException("Unknown AST node type: ${node::class.simpleName}")
         }
+
+    private fun evaluateUninitializedVariableDeclaration(node: UninitializedVariableNode): Value? {
+        val variable = node.variableNode
+        environment.declareVariable(variable.name, variable.type, null, node.declarationType)
+        return null
+    }
 
     private fun evaluateIfStatement(node: IfStatementNode): Value? {
         val condition = evaluate(node.condition)

--- a/modules/interpreter/src/test/kotlin/interpreter/EnvironmentTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/EnvironmentTest.kt
@@ -1,5 +1,6 @@
 package interpreter
 
+import common.enums.DeclarationTypeEnum
 import common.exception.InterpreterException
 import common.exception.TypeMismatchException
 import common.exception.UndefinedVariableException
@@ -41,6 +42,13 @@ class EnvironmentTest {
 
         assertThrows(UninitializedVariableException::class.java) {
             environment.getValue("x")
+        }
+    }
+
+    @Test
+    fun testDeclareUninitializedConstThrowsException() {
+        assertThrows(InterpreterException::class.java) {
+            environment.declareVariable("MY_CONST", common.enums.TypeEnum.STRING, null, DeclarationTypeEnum.CONST)
         }
     }
 

--- a/modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt
@@ -8,6 +8,7 @@ import common.ast.FunctionNode
 import common.ast.IdentifierNode
 import common.ast.IfStatementNode
 import common.ast.LiteralNode
+import common.ast.UninitializedVariableNode
 import common.ast.VariableNode
 import common.enums.DeclarationTypeEnum
 import common.enums.FunctionEnum
@@ -40,6 +41,16 @@ class InterpreterOnePointOneTest {
 
         val result = interpreter.interpret(listOf(declarator))
         assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun testUninitializedConstDeclarationThrowsException() {
+        val variableNode = VariableNode("MY_CONST", TypeEnum.STRING)
+        val declarator = UninitializedVariableNode(variableNode, DeclarationTypeEnum.CONST)
+
+        assertThrows(InterpreterException::class.java) {
+            interpreter.interpret(listOf(declarator))
+        }
     }
 
     @Test

--- a/modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt
+++ b/modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt
@@ -6,6 +6,7 @@ import common.ast.DeclaratorNode
 import common.ast.FunctionNode
 import common.ast.IdentifierNode
 import common.ast.LiteralNode
+import common.ast.UninitializedVariableNode
 import common.ast.VariableNode
 import common.enums.DeclarationTypeEnum
 import common.enums.FunctionEnum
@@ -15,6 +16,7 @@ import common.exception.DivisionByZeroException
 import common.exception.InterpreterException
 import common.exception.TypeMismatchException
 import common.exception.UndefinedVariableException
+import common.exception.UninitializedVariableException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -149,6 +151,18 @@ class InterpreterTest {
 
         val result = interpreter.interpret(listOf(declarator))
         assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun testUseUninitializedVariableThrowsException() {
+        val variableNode = VariableNode("x", TypeEnum.NUMBER)
+        val declarator = UninitializedVariableNode(variableNode, DeclarationTypeEnum.LET)
+        val identifier = IdentifierNode("x")
+        val println = FunctionNode(FunctionEnum.PRINTLN, identifier)
+
+        assertThrows(UninitializedVariableException::class.java) {
+            interpreter.interpret(listOf(declarator, println))
+        }
     }
 
     @Test


### PR DESCRIPTION
This pull request refactors the handling of variable declarations and states in the interpreter, introducing a more robust representation for initialized and uninitialized variables. It also adds support for uninitialized variable declarations in the AST and interpreter, along with comprehensive tests for the new behaviors and error cases.

### Variable State Refactoring

* Replaced the `Variable` data class with a sealed interface `VariableState`, and two implementations: `Initialized` and `Uninitialized`, to explicitly track whether a variable has been initialized. (`modules/interpreter/src/main/kotlin/interpreter/Environment.kt`)
* Updated all usages in `Environment` to work with `VariableState`, including declaration, assignment, and value retrieval, ensuring correct error handling for uninitialized and constant variables. (`modules/interpreter/src/main/kotlin/interpreter/Environment.kt`) [[1]](diffhunk://#diff-825538f674e84c64d88b0db9a9e65015bc5c4c85b5e620e405c7de7ef3800f82L44-R54) [[2]](diffhunk://#diff-825538f674e84c64d88b0db9a9e65015bc5c4c85b5e620e405c7de7ef3800f82L66-R86) [[3]](diffhunk://#diff-825538f674e84c64d88b0db9a9e65015bc5c4c85b5e620e405c7de7ef3800f82L75-R100) [[4]](diffhunk://#diff-825538f674e84c64d88b0db9a9e65015bc5c4c85b5e620e405c7de7ef3800f82L102-R122) [[5]](diffhunk://#diff-825538f674e84c64d88b0db9a9e65015bc5c4c85b5e620e405c7de7ef3800f82L111-R135)

### Interpreter and AST Enhancements

* Added support for `UninitializedVariableNode` in the interpreter, allowing explicit uninitialized variable declarations in the AST and evaluation logic. (`modules/interpreter/src/main/kotlin/interpreter/Interpreter.kt`) [[1]](diffhunk://#diff-53390c3b47fd8e6762f18a66f4dd34d1bbba099ffe9561dfbd159f6bbc6d3fbeR13) [[2]](diffhunk://#diff-53390c3b47fd8e6762f18a66f4dd34d1bbba099ffe9561dfbd159f6bbc6d3fbeR46-R59)

### Testing Improvements

* Added tests to verify that declaring an uninitialized constant throws an exception, and that using an uninitialized variable triggers the correct error. (`modules/interpreter/src/test/kotlin/interpreter/EnvironmentTest.kt`, `modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt`, `modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt`) [[1]](diffhunk://#diff-9003f2f12fec0158bba6bb5533330e32ce7d65d549aa6f8f5e630be9b7572907R48-R54) [[2]](diffhunk://#diff-b1c1dbdc0e4a612a9549af15b7f416598feaa6731be298c962cbe85b0a65e817R46-R55) [[3]](diffhunk://#diff-77a945653399aed2fe6a93242bf498214d49c89fd43b19cef5698ddfaeea9be2R156-R167)
* Updated imports in test files to support new AST node and exception types. (`modules/interpreter/src/test/kotlin/interpreter/EnvironmentTest.kt`, `modules/interpreter/src/test/kotlin/interpreter/InterpreterOnePointOneTest.kt`, `modules/interpreter/src/test/kotlin/interpreter/InterpreterTest.kt`) [[1]](diffhunk://#diff-9003f2f12fec0158bba6bb5533330e32ce7d65d549aa6f8f5e630be9b7572907R3) [[2]](diffhunk://#diff-b1c1dbdc0e4a612a9549af15b7f416598feaa6731be298c962cbe85b0a65e817R11) [[3]](diffhunk://#diff-77a945653399aed2fe6a93242bf498214d49c89fd43b19cef5698ddfaeea9be2R9) [[4]](diffhunk://#diff-77a945653399aed2fe6a93242bf498214d49c89fd43b19cef5698ddfaeea9be2R19)…epresentation